### PR TITLE
Set a define constraint on System.Threading.Tasks.Extensions for Unity versions >= 2021.2

### DIFF
--- a/Editor/Plugins/System.Threading.Tasks.Extensions.dll.meta
+++ b/Editor/Plugins/System.Threading.Tasks.Extensions.dll.meta
@@ -5,7 +5,8 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
-  defineConstraints: []
+  defineConstraints:
+  - '!UNITY_2021_2_OR_NEWER'
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0


### PR DESCRIPTION
Starting from Unity 2021.2, this module is included in mscorlib. To avoid compilation errors we can set a constraint in the meta file for  >= 2021.2